### PR TITLE
add missing magic potion step

### DIFF
--- a/.game_data/magic_potion_post_commit_setup.sh
+++ b/.game_data/magic_potion_post_commit_setup.sh
@@ -31,10 +31,11 @@ makeMagicPotion "knotgrass" "Add 2 bundles of knotgrass to the cauldron."
 makeMagicPotion "crushed-lacewings" "add 2 measures of the crushed lacewings to the cauldron"
 
 makeMagicPotion "stir" "Stir 4 times, clockwise."
+makeMagicPotion "Wave-brew" "Wave your wand then let potion brew for 80 minutes"
 
 # Wrong order
 makeMagicPotion "lacewing-flies" "Add 2 scoops of lacewing flies"
 makeMagicPotion "leeches" "Add 4 leeches to the cauldron."
 
 makeMagicPotion "Heat" "Heat for 30 seconds on a low heat"
-makeMagicPotion "Wave" "Wave your wand to complete this stage of the potion"
+makeMagicPotion "Wave-complete" "Wave your wand to complete this stage of the potion"

--- a/.game_data/magic_potion_validation.sh
+++ b/.game_data/magic_potion_validation.sh
@@ -23,7 +23,7 @@ DIFFERENCE=$(git diff HEAD~4..HEAD~3)
 echo ${DIFFERENCE} | grep '+++ b/cauldron/leeches' > /dev/null 2>&1 || exit 1
 
 # And that the bad ingredient got filtered out.
-DIFFERENCE=$(git diff HEAD~6..HEAD)
+DIFFERENCE=$(git diff HEAD~7..HEAD)
 echo ${DIFFERENCE} | grep '+++ b/cauldron/crushed-lacewings'  > /dev/null 2>&1 && exit 1
 
 # We made it here -> rebase happended as intended!


### PR DESCRIPTION
Signed-off-by: christoph bieri <shopmail404@gmail.com>

The second "wand waving" in the magic_potion.recipe was confusing me in my playthrough, that I tried to reorder/rename the last commit as well. After several attempts I had to look up the solution in the magic_potion_validation.sh.

I would recommend to simply add the missing step. thanks!