### PR TITLE
fix castle md5 check if file have dos newlines

### DIFF
--- a/.game_data/whimsical_elf_validation.sh
+++ b/.game_data/whimsical_elf_validation.sh
@@ -21,7 +21,8 @@ if [[ ! -f "${MD5}" ]] && [[ -f /sbin/md5 ]]; then
 fi
 
 compute_hash() {
-    hash=$(${MD5} < "$1" | cut -d ' ' -f 1)
+    # Remove any DOS newlines before checksum comparison
+    hash=$(tr -d "\r" < $1 | ${MD5} | cut -d ' ' -f 1)
     return 0
 }
 


### PR DESCRIPTION
Signed-off-by: christoph bieri <shopmail404@gmail.com>

I had accidentally set autocrlf in the game git repo and ended up with a crlf castle with diffrent md5 hash as the solution.

The fix is serenity not the best solution, but a quick win.

A better solution could be the definition of line endings in the .gitattributes file, but I didn't try it.
